### PR TITLE
Adds `DynSignatureAlgorithmIdentifier` for PKCS#1 v1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ num-integer = { version = "0.1.39", default-features = false }
 num-iter = { version = "0.1.37", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
+const-oid = { version = "0.9", default-features = false }
 subtle = { version = "2.1.1", default-features = false }
 digest = { version = "0.10.5", default-features = false, features = ["alloc", "oid"] }
 pkcs1 = { version = "0.7.1", default-features = false, features = ["alloc", "pkcs8"] }
@@ -52,10 +53,16 @@ std = ["digest/std", "pkcs1/std", "pkcs8/std", "rand_core/std", "signature/std"]
 pem = ["pkcs1/pem", "pkcs8/pem"]
 pkcs5 = ["pkcs8/encryption"]
 getrandom = ["rand_core/getrandom"]
+algorithm-identifier = ["pkcs1/pkcs8"]
 
 [package.metadata.docs.rs]
-features = ["std", "pem", "serde", "expose-internals", "sha2"]
+features = ["std", "pem", "serde", "expose-internals", "sha2", "algorithm-identifier"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+pkcs1 = { git = "https://github.com/RustCrypto/formats" }
+pkcs8 = { git = "https://github.com/RustCrypto/formats" }
+spki = { git = "https://github.com/RustCrypto/formats" }

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -21,6 +21,9 @@ use signature::{
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 use zeroize::Zeroizing;
 
+#[cfg(feature = "algorithm-identifier")]
+use pkcs8::spki::{der::AnyRef, AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier};
+
 use crate::dummy_rng::DummyRng;
 use crate::errors::{Error, Result};
 use crate::key::{self, PrivateKey, PublicKey};
@@ -436,6 +439,16 @@ where
     }
 }
 
+#[cfg(feature = "algorithm-identifier")]
+impl<D> AssociatedAlgorithmIdentifier for SigningKey<D>
+where
+    D: Digest,
+{
+    type Params = AnyRef<'static>;
+
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifierRef<'static> = pkcs1::ALGORITHM_ID;
+}
+
 impl<D> From<RsaPrivateKey> for SigningKey<D>
 where
     D: Digest,
@@ -604,6 +617,16 @@ where
             phantom: Default::default(),
         }
     }
+}
+
+#[cfg(feature = "algorithm-identifier")]
+impl<D> AssociatedAlgorithmIdentifier for VerifyingKey<D>
+where
+    D: Digest,
+{
+    type Params = AnyRef<'static>;
+
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifierRef<'static> = pkcs1::ALGORITHM_ID;
 }
 
 impl<D> From<RsaPublicKey> for VerifyingKey<D>


### PR DESCRIPTION
This is the bits I was missing from https://github.com/RustCrypto/RSA/pull/284

cc @lumag @tarcieri